### PR TITLE
Fetch meta-updater-qemux86-64 via https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,6 +24,6 @@
 	branch = krogoth
 [submodule "meta-updater-qemux86-64"]
 	path = meta-updater-qemux86-64
-	url = git@github.com:advancedtelematic/meta-updater-qemux86-64
+	url = https://github.com/advancedtelematic/meta-updater-qemux86-64
 	branch = krogoth
 


### PR DESCRIPTION
Otherwise the fetch will fail if the user doesn't have a github ssh key
available.